### PR TITLE
Question routing changes

### DIFF
--- a/frontend/components/navigationButtons.jsx
+++ b/frontend/components/navigationButtons.jsx
@@ -8,8 +8,8 @@ const NavWrapper = styled.nav`
 `
 
 const NavigationButtons = ({ currentQuestionId, surveyLength }) => {
-  const prevQUrl = `/survey/questions/${currentQuestionId - 1}`
-  const nextQUrl = `/survey/questions/${currentQuestionId + 1}`
+  const prevQUrl = `/survey/questions/question/?id=${currentQuestionId - 1}`
+  const nextQUrl = `/survey/questions/question/?id=${currentQuestionId + 1}`
 
   const isFirstQuestion = currentQuestionId === 1
   const isLastQuestion = currentQuestionId === surveyLength

--- a/frontend/components/staticRouting.jsx
+++ b/frontend/components/staticRouting.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import {
+  withRouter as withNextRouter,
+  useRouter as useNextRouter,
+} from 'next/router'
+
+/**
+ * We need this functionality because we are doing a static export
+ * and pushing query strings is dynamic functionality!
+ * See: https://github.com/vercel/next.js/issues/4804
+ *
+ * */
+
+/**
+ * Given a string such as:
+ *
+ * https://example.com/foo?bar=zip&name=Sam
+ *
+ * Will return:
+ *
+ * {
+ *   bar: 'zip',
+ *   name: 'Sam',
+ * }
+ */
+const queryFromUrl = (url) => {
+  const [, ...queryStrings] = url.split('?')
+  const queryString = queryStrings.join('?')
+  const query = {}
+
+  for (let [key, value] of new URLSearchParams(queryString).entries()) {
+    query[key] = value
+  }
+
+  return query
+}
+
+const extractQueryFromRouter = (router) => ({
+  ...queryFromUrl(router.asPath),
+  ...router.query,
+})
+
+/**
+ * Provide a router provider which ensures router.query is always correctly
+ * hydrated on the first render even when statically optimised to avoid [this
+ * caveat from the docs](https://nextjs.org/docs/routing/dynamic-routes):
+ *
+ * > Pages that are statically optimized by Automatic Static Optimization will
+ * > be hydrated without their route parameters provided, i.e `query` will be an
+ * > empty object (`{}`).
+ *
+ * Also injects a `.query` paramter to the `context` in `getInitialProps` making
+ * it more useful than the existing `.asPath`
+ *
+ * Usage is identical to `import { withRouter } from 'next/router';
+ *
+ * Modified from https://github.com/zeit/next.js/issues/4804#issuecomment-541420735
+ */
+export const withRouter = (ComposedComponent) => {
+  const WithPageRouteWrapper = withNextRouter(({ router, ...props }) => {
+    router.query = extractQueryFromRouter(router)
+
+    return <ComposedComponent {...props} router={router} />
+  })
+
+  if (ComposedComponent.getInitialProps) {
+    WithPageRouteWrapper.getInitialProps = (context, ...args) => {
+      context.query = extractQueryFromRouter(context)
+      return ComposedComponent.getInitialProps(context, ...args)
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    const name =
+      ComposedComponent.displayName || ComposedComponent.name || 'Unknown'
+    WithPageRouteWrapper.displayName = `withPageRouter(${name})`
+  }
+
+  return WithPageRouteWrapper
+}
+
+/**
+ * Provide a router hook which ensures router.query is always correctly hydrated
+ * on the first render even when statically optimised to avoid [this caveat from
+ * the docs](https://nextjs.org/docs/routing/dynamic-routes):
+ *
+ * > Pages that are statically optimized by Automatic Static Optimization will
+ * > be hydrated without their route parameters provided, i.e `query` will be an
+ * > empty object (`{}`).
+ *
+ * Usage is identical to `import { useRouter } from 'next/router';
+ */
+export const useRouter = () => {
+  const router = useNextRouter()
+  router.query = extractQueryFromRouter(router)
+  return router
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,4 +3,5 @@ module.exports = {
     API_URL: process.env.API_URL,
     PORT: process.env.PORT,
   },
+  trailingSlash: true,
 }

--- a/frontend/pages/survey/questions/question.jsx
+++ b/frontend/pages/survey/questions/question.jsx
@@ -1,15 +1,15 @@
 import React, { useEffect } from 'react'
 import Head from 'next/head'
 import styled from 'styled-components'
-import { useRouter } from 'next/router'
 import { useStore } from '../../../store'
 
 import InnerContentWrapper from '../../../components/shared/InnerContentWrapper'
-import Link from '../../../components/link'
 import Option from '../../../components/option'
 import NavigationButtons from '../../../components/navigationButtons'
 import ProgressBar from '../../../components/progressBar'
 import { getAll as getAllQuestions } from '../../../services/questions'
+import { useRouter, withRouter } from '../../../components/staticRouting'
+import Link from 'next/link'
 
 const OptionsWrapper = styled.div`
   display: grid;
@@ -48,24 +48,21 @@ const QuestionNumber = styled.span`
 const Question = () => {
   const router = useRouter()
   const store = useStore()
-  
+
   const questions = store.questions
 
   const optionsToPointsMap = useStore((state) => state.optionsToPointsMap)
 
-  const questionId = Number(router.query.questionId)
+  const questionId = Number(router.query.id)
   const summaryPageHref = '/survey/questions/summary'
   const isFinalQuestion = questionId === questions.length
 
   useEffect(() => {
-      
-    (async () => {
-
-        if ( store.questions.length === 0 ) {
-          const response = await getAllQuestions()
-          store.setQuestions(response)
-        }
-
+    ;(async () => {
+      if (store.questions.length === 0) {
+        const response = await getAllQuestions()
+        store.setQuestions(response)
+      }
     })()
   }, [])
 
@@ -75,12 +72,8 @@ const Question = () => {
     store.setSelections(newSelections)
   }
   // this needs to be changed, but is here for placeholder
-  if ( store.questions.length === 0 ) {
-      return (
-          <div>
-              Loading questions...
-          </div>
-      )
+  if (store.questions.length === 0) {
+    return <div>Loading questions...</div>
   }
 
   return (
@@ -99,7 +92,7 @@ const Question = () => {
         <OptionsWrapper>
           {Object.keys(optionsToPointsMap).map((optionLabel) => {
             const pointsAssociatedWithOption = optionsToPointsMap[optionLabel]
-            
+
             return (
               <Option
                 key={pointsAssociatedWithOption}
@@ -118,12 +111,13 @@ const Question = () => {
           surveyLength={questions.length}
         />
         {isFinalQuestion ? (
-          <Link href={summaryPageHref} type="primary">Review</Link>
+          <Link href={summaryPageHref} type="primary">
+            Review
+          </Link>
         ) : null}
       </InnerContentWrapper>
     </>
   )
 }
 
-
-export default Question
+export default withRouter(Question)

--- a/frontend/pages/survey/signup.jsx
+++ b/frontend/pages/survey/signup.jsx
@@ -41,7 +41,7 @@ const SignUpForm = () => {
   const [emailInput, setEmailInput] = useState('')
   const router = useRouter()
   const store = useStore()
-  const firstQuestionHref = '/survey/questions/1'
+  const firstQuestionHref = '/survey/questions/question/?id=1'
 
   const handleEmailChange = (event) => {
     event.preventDefault()

--- a/frontend/tests/pages/Question.spec.jsx
+++ b/frontend/tests/pages/Question.spec.jsx
@@ -9,7 +9,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { useRouter } from 'next/router'
 import { useStore } from '../../store'
 
-import Question from '../../pages/survey/questions/[questionId]'
+import Question from '../../pages/survey/questions/question'
 import ThemeWrapper from '../testutils/themeWrapper'
 import { questions } from '../testutils/mockQuestions'
 

--- a/frontend/tests/pages/Question.spec.jsx
+++ b/frontend/tests/pages/Question.spec.jsx
@@ -26,9 +26,9 @@ describe('Question rendering', () => {
     })
 
     useRouter.mockImplementation(() => ({
-      route: '/survey/questions/1',
-      pathname: 'survey/questions/1',
-      query: { questionId: '1' },
+      route: '/survey/questions/question/?id=1',
+      pathname: 'survey/questions/question/?id=1',
+      query: { id: '1' },
       asPath: '',
     }))
 
@@ -87,9 +87,9 @@ describe('Navigation button conditional rendering', () => {
   it('Mid-survey question renders links with texts Back and Next', () => {
 
     useRouter.mockImplementation(() => ({
-      route: '/survey/questions/2',
-      pathname: 'survey/questions/2',
-      query: { questionId: '2' },
+      route: '/survey/questions/question/?id=2',
+      pathname: 'survey/questions/question/?id=2',
+      query: { id: '2' },
       asPath: '',
     }))
 
@@ -105,9 +105,9 @@ describe('Navigation button conditional rendering', () => {
 
   it('Last question renders link with text Back and link to summary', () => {
     useRouter.mockImplementation(() => ({
-      route: '/survey/questions/3',
-      pathname: 'survey/questions/3',
-      query: { questionId: '3' },
+      route: '/survey/questions/question/?id=3',
+      pathname: 'survey/questions/question/?id=3',
+      query: { id: '3' },
       asPath: '',
     }))
     


### PR DESCRIPTION
- made question page static (removed the [ ] ) -> questions are now transitioned between using the question id as a query string

- added a staticRouting file with methods to enable pushing of query strings to the now static question page since this would otherwise not be possible. NB: the custom useRouter works the same way as the native useRouter
- added missing trailing slash config to prevent crash on refresh

Everything seems to work!

Fixes #136 