### PR TITLE
prevent progress bar from disappearing

### DIFF
--- a/frontend/components/progressBar.jsx
+++ b/frontend/components/progressBar.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import LinearProgress from '@material-ui/core/LinearProgress'
 
-const BarBackground = styled.div`
+const BarBackground = styled.section`
   display: flex;
   align-items: center;
   background-color: ${({ theme }) => theme.colors.blueDianne};
@@ -27,11 +27,6 @@ const ProgressLine = styled.div`
   height: 0.3rem;
   border-radius: 0.1rem;
   width: ${({ progress }) => progress}%;
-`
-
-const ProgressWrapper = styled.div`
-  .MuiLinearProgress {
-  }
 `
 
 /*


### PR DESCRIPTION
closes #219 

Post mortem for this bug:
- related to SSR, we had the exact same issue with the content wrapper
- only occurred on question page
- solution: wrappers cannot be divs on question page, any other element seems to work (e.g. section, article) - I suspect that this has something to do with the fact that our question page is static, but dynamic in nature, which confuses nextjs
