### PR TITLE
fix documentation links to point to main

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,26 +5,26 @@ further development of the application.
 
 The documentation has the following content:
 
-* [service description](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/service-description.md)
+* [service description](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/service-description.md)
 
-* [architecture description](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/architecture.md)
+* [architecture description](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/architecture.md)
 
-* [backend API documentation](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/backend-api.md)
+* [backend API documentation](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/backend-api.md)
 
-* [database diagram](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/database-diagram.md)
+* [database diagram](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/database-diagram.md)
 
-* [installation and deployment instructions](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/installation-and-deployment.md)
+* [installation and deployment instructions](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/installation-and-deployment.md)
 
-* [testing document](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/testing.md)
+* [testing document](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/testing.md)
 
-* [CI pipeline description](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/ci-pipeline-architecture.md)
+* [CI pipeline description](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/ci-pipeline-architecture.md)
 
-* [accessibility guidelines](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/general-a11y-guidelines.md)
+* [accessibility guidelines](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/general-a11y-guidelines.md)
 
-* [maintenance instructions](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/maintenance-and-version-control.md)
+* [maintenance instructions](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/maintenance-and-version-control.md)
 
-* [JSON instructions for survey content management](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/json-instructions.md)
+* [JSON instructions for survey content management](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/json-instructions.md)
 
-* [GDPR](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/gdpr.md)
+* [GDPR](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/gdpr.md)
 
-* [answers to general question in handover template](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/documentation/documentation/general.md)
+* [answers to general question in handover template](https://github.com/Devops-ohtuprojekti/DevOpsCSAOS/blob/main/documentation/general.md)


### PR DESCRIPTION
The links in the readme pointed to the documentation branch. Now changed to point to main.